### PR TITLE
Install pigz and socat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
 	  texinfo lzop apt-utils bc screen libncurses5-dev locales \
           libc6-dev-i386 doxygen libssl-dev dos2unix xvfb x11-utils \
 	  g++-multilib libssl-dev:i386 libcrypto++-dev:i386 zlib1g-dev:i386 \
-	  libtool libtool-bin procps python3-distutils && \
+	  libtool libtool-bin procps python3-distutils pigz socat && \
 	rm -rf /var/lib/apt-lists/* && \
 	echo "dash dash/sh boolean false" | debconf-set-selections && \
 	DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash


### PR DESCRIPTION
Pigz speeds up sstate cache operations due to parallelization and socat
needed for proxy setups

Signed-off-by: Khem Raj <raj.khem@gmail.com>