### PR TITLE
Dockerfile: Add python3-jinja2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN \
 	  texinfo lzop apt-utils bc screen libncurses5-dev locales \
           libc6-dev-i386 doxygen libssl-dev dos2unix xvfb x11-utils \
 	  g++-multilib libssl-dev:i386 libcrypto++-dev:i386 zlib1g-dev:i386 \
-	  libtool libtool-bin procps python3-distutils pigz socat && \
+	  libtool libtool-bin procps python3-distutils pigz socat \
+	  python3-jinja2 && \
 	rm -rf /var/lib/apt-lists/* && \
 	echo "dash dash/sh boolean false" | debconf-set-selections && \
 	DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash


### PR DESCRIPTION
jinja2 is needed by resulttool to report output of -ctestimage
into human readable text

Signed-off-by: Khem Raj <raj.khem@gmail.com>