### PR TITLE
Dockerfile: install tmux to fix devshell for uid without passwd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
         apt-get update && \
 	apt-get install -yq sudo build-essential git \
 	  python python3 man bash diffstat gawk chrpath wget cpio \
-	  texinfo lzop apt-utils bc screen libncurses5-dev locales \
+	  texinfo lzop apt-utils bc screen tmux libncurses5-dev locales \
           libc6-dev-i386 doxygen libssl-dev dos2unix xvfb x11-utils \
 	  g++-multilib libssl-dev:i386 libcrypto++-dev:i386 zlib1g-dev:i386 \
 	  libtool libtool-bin procps python3-distutils pigz socat \


### PR DESCRIPTION
Installing tmux and relaying on the auto terminal devshell feature
allows us to use the devshell for users without proper passwd
entries.