### PR TITLE
Support mappable dynamic build user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Cliff Brake <cbrake@bec-systems.com>
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Override user name at build. If build-arg is not passed, will create user named `default_user`
+ARG DOCKER_USER=build
+
 RUN \
 	dpkg --add-architecture i386 && \
         apt-get update && \
@@ -14,18 +17,28 @@ RUN \
 	  libtool libtool-bin procps python3-distutils pigz socat \
 	  python3-jinja2 python3-pip python3-pexpect lz4 zstd unzip xz-utils \
 	  debianutils iputils-ping python3-git pylint3 python3-subunit \
-	  iproute2 && \
+	  iproute2 curl && \
 	rm -rf /var/lib/apt-lists/* && \
 	echo "dash dash/sh boolean false" | debconf-set-selections && \
 	dpkg-reconfigure dash
 
-RUN useradd -ms /bin/bash -p build build && \
-	usermod -aG sudo build
+# Create a group and user
+RUN addgroup "$DOCKER_USER" && \
+    useradd -ms /bin/bash -g $DOCKER_USER -G sudo $DOCKER_USER && \
+    echo "${DOCKER_USER}:${DOCKER_USER}" | chpasswd  && \
+    echo 'build ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.16/gosu-$(dpkg --print-architecture)" && \
+    chmod +x /usr/local/bin/gosu
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
 ENV LANG en_US.utf8
 
-USER build
-WORKDIR /home/build
+COPY files /
+
+RUN chmod 0755 /entrypoint \
+ && sed "s/\$DOCKER_USER/$DOCKER_USER/g" -i /entrypoint
+
+ENTRYPOINT ["/entrypoint"]

--- a/files/entrypoint
+++ b/files/entrypoint
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+  
+set -e
+set -u
+#set -x
+
+: "${UUID:=0}"
+: "${GGID:=${UUID}}"
+if [ "$UUID" != "0" ]
+then
+        usermod -u $UUID $DOCKER_USER 2>/dev/null && {
+                groupmod -g $GGID $DOCKER_USER 2>/dev/null ||
+                usermod -a -G $GGID $DOCKER_USER
+        }
+        exec gosu ${UUID}:${GGID} "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Use entrypoint to ensure correct user ID and group IDs are mapped to docker build user, this should help fix

https://github.com/YoeDistro/yoe-distro/issues/7