### PR TITLE
install binfmt-support qemu-user-static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
 	  libtool libtool-bin procps python3-distutils pigz socat \
 	  python3-jinja2 python3-pip python3-pexpect lz4 zstd unzip xz-utils \
 	  debianutils iputils-ping python3-git pylint python3-subunit \
-	  iproute2 curl iptables && \
+	  iproute2 curl iptables binfmt-support qemu-user-static && \
 	apt-get -yq upgrade && \
 	rm -rf /var/lib/apt-lists/* && \
 	dpkg-divert --remove --no-rename /usr/share/man/man1/sh.1.gz && \


### PR DESCRIPTION
This helps running static x86_64 binaries on say ARM64 hosts See https://github.com/OE4T/meta-tegra/issues/1867